### PR TITLE
Update jdk 21 to 21.0.1-ga

### DIFF
--- a/.github/workflows/openjdk-21.yml
+++ b/.github/workflows/openjdk-21.yml
@@ -10,8 +10,8 @@ on:
         type: boolean
 
 env:
-  JDK_TARBALL_URL: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.1-12.tar.gz
-  PKG_NAME_AND_VERSION: openjdk-21_21.0.1-ga
+  JDK_TARBALL_URL: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.1+12.tar.gz
+  PKG_NAME_AND_VERSION: openjdk-21_21.0.1+12
 
 jobs:
   build:

--- a/.github/workflows/openjdk-21.yml
+++ b/.github/workflows/openjdk-21.yml
@@ -10,8 +10,8 @@ on:
         type: boolean
 
 env:
-  JDK_TARBALL_URL: https://github.com/openjdk/jdk/archive/refs/tags/jdk-21+35.tar.gz
-  PKG_NAME_AND_VERSION: openjdk-21_21+35
+  JDK_TARBALL_URL: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.1-12.tar.gz
+  PKG_NAME_AND_VERSION: openjdk-21_21.0.1-ga
 
 jobs:
   build:

--- a/openjdk-21/debian/changelog
+++ b/openjdk-21/debian/changelog
@@ -1,4 +1,4 @@
-openjdk-21 (21.0.1+12-1) unstable; urgency=high
+openjdk-21 (21.0.1+12-1) focal; urgency=high
 
   * OpenJDK 21.0.1 release, build 12.
     - CVE-2023-22081, CVE-2023-22025.

--- a/openjdk-21/debian/changelog
+++ b/openjdk-21/debian/changelog
@@ -1,3 +1,12 @@
+openjdk-21 (21.0.1+12-1) unstable; urgency=high
+
+  * OpenJDK 21.0.1 release, build 12.
+    - CVE-2023-22081, CVE-2023-22025.
+    - Release notes:
+      https://www.oracle.com/java/technologies/javase/21-0-1-relnotes.html
+
+ -- Cryptobot <releases@cryptomator.org>  Wed, 25 Oct 2023 12:50:00 +0200
+
 openjdk-21 (21+35-0ppa2) focal; urgency=low
 
   * see https://jdk.java.net/21/release-notes

--- a/openjdk-21/debian/changelog
+++ b/openjdk-21/debian/changelog
@@ -1,11 +1,11 @@
-openjdk-21 (21.0.1+12-1) focal; urgency=high
+openjdk-21 (21.0.1+12-0ppa1) focal; urgency=high
 
   * OpenJDK 21.0.1 release, build 12.
     - CVE-2023-22081, CVE-2023-22025.
     - Release notes:
       https://www.oracle.com/java/technologies/javase/21-0-1-relnotes.html
 
- -- Cryptobot <releases@cryptomator.org>  Wed, 25 Oct 2023 12:50:00 +0200
+ -- Cryptobot <releases@cryptomator.org>  Wed, 26 Oct 2023 10:50:00 +0200
 
 openjdk-21 (21+35-0ppa2) focal; urgency=low
 

--- a/openjdk-21/debian/rules
+++ b/openjdk-21/debian/rules
@@ -5,7 +5,7 @@
 #export DH_VERBOSE=1
 
 BOOT_JDK_PATH = /usr/lib/jvm/java-20-coffeelibs
-JDK_BUILD_NO = 35
+JDK_VERSION = 21.0.1+12-1
 
 %:
 	dh $@
@@ -18,7 +18,7 @@ override_dh_auto_configure:
 	--with-conf-name=coffeelibs-openjdk-21 \
 	--with-boot-jdk=$(BOOT_JDK_PATH) \
 	--with-version-pre= \
-	--with-version-build=$(JDK_BUILD_NO) \
+	--with-version-string=$(JDK_VERSION) \
 	--with-version-opt=coffeelibs \
 	--with-native-debug-symbols=none
 


### PR DESCRIPTION
Build can be found here: https://github.com/coffeelibs/ppa-openjdk/actions/runs/6639418642/job/18045993294
PPA build: https://launchpad.net/~coffeelibs/+archive/ubuntu/openjdk/+sourcepub/15338283/+listing-archive-extra 

In the rules file, instead of setting only the build number, the complete version string is set. According ot [JDK documentation](https://github.com/openjdk/jdk21u/blob/5dd22a9bef21140f01c1407162bc4b4cff16e9f2/doc/building.md#configure-arguments-for-tailoring-the-build), the version set with `--with-version-string=<string>` is altered by the `--with-version-<part>=<value>` options.

Build tested (x64 versions, compile+run jfuse and cryptomator) on ubuntu
  * [x] 20.04
  * [x] 22.04 

I also had a look at the debian build repo of the openjdk (https://salsa.debian.org/openjdk-team/openjdk/-/tree/openjdk-21/debian?ref_type=heads). There they bumped the debhelper version to 11. We should consider, if we also need that.