### PR TITLE
Feature: Drop JEP 493

### DIFF
--- a/.github/workflows/openjdk-24.yml
+++ b/.github/workflows/openjdk-24.yml
@@ -3,6 +3,11 @@ name: Build OpenJDK-24
 on:
   workflow_dispatch:
     inputs:
+      provide-jdk:
+        description: 'Upload to Artifacts'
+        required: false
+        default: false
+        type: boolean
       dput:
         description: 'Upload to PPA'
         required: true
@@ -55,12 +60,23 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: deb-package
+          name: reduced-deb-package
           path: |
             openjdk-${{ env.JDK_MAJOR_VERSION }}_*.dsc
             openjdk-${{ env.JDK_MAJOR_VERSION }}_*.debian.tar.xz
             openjdk-${{ env.JDK_MAJOR_VERSION }}_*_source.buildinfo
             openjdk-${{ env.JDK_MAJOR_VERSION }}_*_source.changes
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        if: inputs.provide-jdk
+        with:
+          name: full-deb-package
+          path: |
+            openjdk-${{ env.JDK_MAJOR_VERSION }}_*.dsc
+            openjdk-${{ env.JDK_MAJOR_VERSION }}_*.debian.tar.xz
+            openjdk-${{ env.JDK_MAJOR_VERSION }}_*_source.buildinfo
+            openjdk-${{ env.JDK_MAJOR_VERSION }}_*_source.changes
+            coffeelibs-jdk-${{ env.JDK_MAJOR_VERSION }}_*.deb
       - name: Publish on PPA
         if: inputs.dput
         run: dput ppa:coffeelibs/openjdk openjdk-${{env.JDK_MAJOR_VERSION}}_*_source.changes

--- a/.github/workflows/openjdk-24.yml
+++ b/.github/workflows/openjdk-24.yml
@@ -3,11 +3,6 @@ name: Build OpenJDK-24
 on:
   workflow_dispatch:
     inputs:
-      provide-jdk:
-        description: 'Upload to Artifacts'
-        required: false
-        default: false
-        type: boolean
       dput:
         description: 'Upload to PPA'
         required: true
@@ -60,23 +55,12 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: reduced-deb-package
+          name: deb-package
           path: |
             openjdk-${{ env.JDK_MAJOR_VERSION }}_*.dsc
             openjdk-${{ env.JDK_MAJOR_VERSION }}_*.debian.tar.xz
             openjdk-${{ env.JDK_MAJOR_VERSION }}_*_source.buildinfo
             openjdk-${{ env.JDK_MAJOR_VERSION }}_*_source.changes
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        if: inputs.provide-jdk
-        with:
-          name: full-deb-package
-          path: |
-            openjdk-${{ env.JDK_MAJOR_VERSION }}_*.dsc
-            openjdk-${{ env.JDK_MAJOR_VERSION }}_*.debian.tar.xz
-            openjdk-${{ env.JDK_MAJOR_VERSION }}_*_source.buildinfo
-            openjdk-${{ env.JDK_MAJOR_VERSION }}_*_source.changes
-            coffeelibs-jdk-${{ env.JDK_MAJOR_VERSION }}_*.deb
       - name: Publish on PPA
         if: inputs.dput
         run: dput ppa:coffeelibs/openjdk openjdk-${{env.JDK_MAJOR_VERSION}}_*_source.changes

--- a/openjdk-24/debian/changelog
+++ b/openjdk-24/debian/changelog
@@ -1,3 +1,10 @@
+openjdk-24 (24.0.1+9-0ppa3) jammy; urgency=low
+
+  * drop JEP 493 and publish with jmods
+  * see https://jdk.java.net/24/release-notes
+
+ -- Cryptobot <releases@cryptomator.org>  Tue, 20 May 2025 17:00:00 +0200
+
 openjdk-24 (24.0.1+9-0ppa2) jammy; urgency=low
 
   * fixed build dependencies

--- a/openjdk-24/debian/coffeelibs-jdk-24.install
+++ b/openjdk-24/debian/coffeelibs-jdk-24.install
@@ -2,6 +2,7 @@ build/coffeelibs-openjdk-24/images/jdk/bin usr/lib/jvm/java-24-coffeelibs
 build/coffeelibs-openjdk-24/images/jdk/conf usr/lib/jvm/java-24-coffeelibs
 build/coffeelibs-openjdk-24/images/jdk/demo usr/lib/jvm/java-24-coffeelibs
 build/coffeelibs-openjdk-24/images/jdk/include usr/lib/jvm/java-24-coffeelibs
+build/coffeelibs-openjdk-24/images/jdk/jmods usr/lib/jvm/java-24-coffeelibs
 build/coffeelibs-openjdk-24/images/jdk/legal usr/lib/jvm/java-24-coffeelibs
 build/coffeelibs-openjdk-24/images/jdk/lib usr/lib/jvm/java-24-coffeelibs
 build/coffeelibs-openjdk-24/images/jdk/man usr/lib/jvm/java-24-coffeelibs

--- a/openjdk-24/debian/rules
+++ b/openjdk-24/debian/rules
@@ -21,7 +21,7 @@ override_dh_auto_configure:
 	--with-version-string=$(JDK_VERSION) \
 	--with-version-opt=coffeelibs \
 	--with-native-debug-symbols=none \
-	--enable-linkable-runtime
+	--with-source-date=current
 
 override_dh_auto_build:
 	make jdk-image


### PR DESCRIPTION
This PR removes the `enable-linkable-runtime`  flag from the JDK 24 build again.

The reason is, that for unknown reasons the `jlink` tool cannot be used. Everytime it is called, it stops with the error "Error: [file/xyz] has been modified". 

Example can be found in https://github.com/cryptomator/cryptomator/actions/runs/15032359229/job/42247421565#step:12:95)
```
dpkg-buildpackage -us -uc -ui -S -sa -d
dpkg-buildpackage: info: source package cryptomator
dpkg-buildpackage: info: source version 1.16.0+1.17.0~alpha1-0ppa1
dpkg-buildpackage: info: source distribution focal
dpkg-buildpackage: info: source changed by Cryptobot <releases@cryptomator.org>
 dpkg-source --before-build .
 fakeroot debian/rules clean
dh clean
   debian/rules override_dh_auto_clean
make[1]: Entering directory '/home/runner/work/cryptomator/cryptomator/cryptomator_1.16.0+1.17.0~alpha1'
rm -rf runtime
rm -rf cryptomator
rm -rf debian/cryptomator
rm -rf resources
make[1]: Leaving directory '/home/runner/work/cryptomator/cryptomator/cryptomator_1.16.0+1.17.0~alpha1'
   dh_clean
 dpkg-source -b .
dpkg-source: info: using source format '3.0 (quilt)'
dpkg-source: info: building cryptomator using existing ./cryptomator_1.16.0+1.17.0~alpha1.orig.tar.xz
dpkg-source: info: building cryptomator in cryptomator_1.16.0+1.17.0~alpha1-0ppa1.debian.tar.xz
dpkg-source: info: building cryptomator in cryptomator_1.16.0+1.17.0~alpha1-0ppa1.dsc
 dpkg-genbuildinfo --build=source -O../cryptomator_1.16.0+1.17.0~alpha1-0ppa1_source.buildinfo
 dpkg-genchanges -sa --build=source -O../cryptomator_1.16.0+1.17.0~alpha1-0ppa1_source.changes
dpkg-genchanges: info: including full source code in upload
 dpkg-source --after-build .
dpkg-buildpackage: info: source-only upload (original source is included)
Now running lintian cryptomator_1.16.0+1.17.0~alpha1-0ppa1_source.changes ...
W: cryptomator source: inconsistent-appstream-metadata-license common/org.cryptomator.Cryptomator.metainfo.xml (fsfap != gpl-3+) [debian/copyright]
W: cryptomator source: superfluous-file-pattern debian/org.cryptomator.Cryptomator.appdata.xml [debian/copyright:10]
Finished running lintian.
Now signing changes and any dsc files...
 signfile dsc cryptomator_1.16.0+1.17.0~alpha1-0ppa1.dsc Cryptobot <releases@cryptomator.org>

 fixup_buildinfo cryptomator_1.16.0+1.17.0~alpha1-0ppa1.dsc cryptomator_1.16.0+1.17.0~alpha1-0ppa1_source.buildinfo
 signfile buildinfo cryptomator_1.16.0+1.17.0~alpha1-0ppa1_source.buildinfo Cryptobot <releases@cryptomator.org>

 fixup_changes dsc cryptomator_1.16.0+1.17.0~alpha1-0ppa1.dsc cryptomator_1.16.0+1.17.0~alpha1-0ppa1_source.changes
 fixup_changes buildinfo cryptomator_1.16.0+1.17.0~alpha1-0ppa1_source.buildinfo cryptomator_1.16.0+1.17.0~alpha1-0ppa1_source.changes
 signfile changes cryptomator_1.16.0+1.17.0~alpha1-0ppa1_source.changes Cryptobot <releases@cryptomator.org>

Successfully signed dsc, buildinfo, changes files
 dpkg-buildpackage -us -uc -ui -b -sa -d
dpkg-buildpackage: info: source package cryptomator
dpkg-buildpackage: info: source version 1.16.0+1.17.0~alpha1-0ppa1
dpkg-buildpackage: info: source distribution focal
dpkg-buildpackage: info: source changed by Cryptobot <releases@cryptomator.org>
 dpkg-source --before-build .
dpkg-buildpackage: info: host architecture amd64
 fakeroot debian/rules clean
dh clean
   debian/rules override_dh_auto_clean
make[1]: Entering directory '/home/runner/work/cryptomator/cryptomator/cryptomator_1.16.0+1.17.0~alpha1'
rm -rf runtime
rm -rf cryptomator
rm -rf debian/cryptomator
rm -rf resources
make[1]: Leaving directory '/home/runner/work/cryptomator/cryptomator/cryptomator_1.16.0+1.17.0~alpha1'
   dh_clean
 debian/rules build
dh build
   dh_update_autotools_config
   dh_autoreconf
   debian/rules override_dh_auto_build
make[1]: Entering directory '/home/runner/work/cryptomator/cryptomator/cryptomator_1.16.0+1.17.0~alpha1'
mkdir resources
ln -s ../common/org.cryptomator.Cryptomator512.png resources/cryptomator.png
/usr/lib/jvm/java-24-coffeelibs/bin/jlink \
	--output runtime \
	--module-path "jmods/amd64" \
	--add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,javafx.base,javafx.graphics,javafx.controls,javafx.fxml,jdk.unsupported,jdk.security.auth,jdk.accessibility,jdk.management.jfr,jdk.net,java.compiler \
	--strip-native-commands \
	--no-header-files \
	--no-man-pages \
	--strip-debug \
	--compress zip-0
Error: /usr/lib/jvm/java-24-coffeelibs/lib/libextnet.so has been modified
make[1]: *** [debian/rules:27: override_dh_auto_build] Error 1
make[1]: Leaving directory '/home/runner/work/cryptomator/cryptomator/cryptomator_1.16.0+1.17.0~alpha1'
make: *** [debian/rules:16: build] Error 2
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
debuild: fatal error at line 1182:
dpkg-buildpackage -us -uc -ui -b -sa -d failed
```

I asked the mailing list about the issue https://mail.openjdk.org/pipermail/build-dev/2025-May/050829.html, but until a proper response we need to build regular JDK with jmods.